### PR TITLE
Fixed Access Violation.

### DIFF
--- a/src/pmpq_io.c
+++ b/src/pmpq_io.c
@@ -330,7 +330,7 @@ PGMP_PG_FUNCTION(pmpq_to_numeric)
 {
     const mpq_t     q;
     int32           typmod;
-    unsigned long   scale;
+    long            scale;
     mpz_t           z;
     char            *buf;
     int             sbuf, snum;


### PR DESCRIPTION
In pmpq_to_numeric function ```end[-scale] = '.';``` statement raises an Access Violation exception if scale is an unsigned long as -scale is still an unsgined long.