### PR TITLE
Makefile: POSIX-ify sed commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - sudo make install
 
 script:
-  - make installcheck
+  - if ! make installcheck; then cat regression.diffs && false; fi
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ EXTENSION = pgmp
 MODULEDIR = $(EXTENSION)
 MODULE_big = $(EXTENSION)
 
-EXT_LONGVER = $(shell grep '"version":' META.json | head -1 | sed -e 's/\s*"version":\s*"\(.*\)",/\1/')
-EXT_SHORTVER = $(shell grep 'default_version' $(EXTENSION).control | head -1 | sed -e "s/default_version\s*=\s'\(.*\)'/\1/")
+EXT_LONGVER = $(shell grep '"version":' META.json | head -1 | sed -e 's/[[:space:]]*"version":[[:space:]]*"\(.*\)",/\1/')
+EXT_SHORTVER = $(shell grep 'default_version' $(EXTENSION).control | head -1 | sed -e "s/default_version[[:space:]]*=[[:space:]]'\(.*\)'/\1/")
 
 SRC_C = $(sort $(wildcard src/*.c))
 SRC_H = $(sort $(wildcard src/*.h))


### PR DESCRIPTION
Without this, build and pgxn installations fail on Mac OS X.
The error is described in https://github.com/dvarrazzo/pgmp/issues/4.

According to [1], this is because `\s` is a GNU sed extension,
and `[[:space:]]` is the appropriate POSIX character class.
Changing this removes the warnings and ultimate error.

[1]: https://superuser.com/a/112837