### PR TITLE
Add bytea casts

### DIFF
--- a/sql/pgmp.pysql
+++ b/sql/pgmp.pysql
@@ -118,6 +118,7 @@ castfrom('int8', implicit='I')
 castfrom('float4', implicit='A')
 castfrom('float8', implicit='A')
 castfrom('numeric', implicit='A')
+castfrom('bytea', implicit='A')
 
 def castto(typname, implicit=False):
     """Create a cast from `base_type` to a different type"""
@@ -134,6 +135,7 @@ castto('int4', implicit='A')
 castto('int2', implicit='A')
 castto('float4', implicit='A')
 castto('float8', implicit='A')
+castto('bytea', implicit='A')
 
 !! PYOFF
 
@@ -288,7 +290,7 @@ CREATE OPERATOR <> (
 
 def bop(sym, fname, comm, neg):
     """Create an operator on `base_type` returning a bool"""
-    func('%s_%s' % (base_type, fname), 
+    func('%s_%s' % (base_type, fname),
         base_type + " " + base_type, argout='boolean')
     fname1 = fname[0] + 't'
 


### PR DESCRIPTION
Submitted for consideration of whether this is something useful to upstream. This shouldn't be merged as-is (no docs or benchmarks yet.)

This patch enables *efficient* interconversion between `mpz` and `bytea`, where the `bytea` is interpreted as a "packed big-endian" or "base-256" bitstring representation of an integer.

-----

Our company works to analyze data sourced from Ethereum, where most numeric data is represented as a "uint256" (256-bit unsigned integer) type, usually transmitted serialized as a hex value. We store billions of these uint256 values in our DB. We index them, aggregate over them, and also bulk-`encode(them, 'hex')` for presentation. Sometimes they're actually numbers. Sometimes they're not. Thinking of the raw data as something more like "arbitrary contents of a 32-byte-wide machine vector register" might make more sense.

We have found that storing the data as `numeric`, while efficient for math, is highly inefficient for converting-to-hex (it's very difficult to write a native base conversion routine between `numeric's` base-10000, and hex's base-16.) Storing the data as an `mpz` would almost work, but breaks wire compatibility for clients that want to consume the data in its native binary representation (e.g. Elixir's `Postgrex` library.)

Ultimately, we have chosen to store these values in Postgres as raw `bytea`s. This gives us the highest storage efficiency; allows us to use the native, highly-efficient Postgres function `encode(col, 'hex')`; and also is a lossless transformation from the original hex-encoded representation, for cases where the value turns out to be non-numeric (e.g. a packed struct) where we'd want to retain and re-create leading zeroes on encode.

A `bytea` would normally have no efficient path to performing math operations upon, but with this patch, we can cheaply cast `bytea` values to `mpz`, perform the aggregate, and _then_ encode the result as hex (or back to `bytea`).

This has worked exceedingly well for us so far. We have been using this patch in production for around two years now, with no hiccups.

The only issue with it, is that it's not upstreamed, so we have to manually build and install our own fork of `pgmp` for every Postgres instance we run!

If you like this code/the idea behind it, let me know what should be done to polish it up and get it ready to contribute. Thanks!

-----

P.S. In our production databases, we have also defined implicit assignment casts between the `numeric` and `bytea` types, that take the value through `mpz` as an intermediate representation. The cast from `mpz` to `numeric` is not particularly efficient, but due to GMP's highly-efficient data structures, it seemed to still be cheaper for bulk conversions than the memory access pattern created by the naive direct base-256 to base-10000 conversion routine I wrote as an alternative. (Though, obviously, `pmpq_to_numeric` could probably still be optimized further; it allocates an intermediate string!)

However efficient it is, it's _definitely_ a better option than doing this base-conversion in PL/pgSQL. And that fact—plus having it "built in" to a library that gets packaged by Debian et al—is "good enough" for us, and probably most people. As such, it might make sense to consider having this library also define `bytea`↔`numeric` casts, iff the DB doesn't already have them.