### PR TITLE
Make Makefile more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,17 +31,10 @@ EXTENSION = pgmp
 MODULEDIR = $(EXTENSION)
 MODULE_big = $(EXTENSION)
 
-ifeq ($(shell sed --version 2>/dev/null | grep -q GNU && echo gnu),gnu)
-	LONGVER_MATCHER = 's/\s*"version":\s*"\(.*\)",/\1/'
-	SHORTVER_MATCHER = "s/default_version\s*=\s'\(.*\)'/\1/"
-else
-  # Adapt syntax for POSIX (FreeBSD)
-	LONGVER_MATCHER = 's/[[:space:]]*"version":[[:space:]]*"\(.*\)",/\1/'
-	SHORTVER_MATCHER = "s/default_version[[:space:]]*=[[:space:]]'\(.*\)'/\1/"
-endif
-
-EXT_LONGVER = $(shell grep '"version":' META.json | head -1 | sed -e $(LONGVER_MATCHER))
-EXT_SHORTVER = $(shell grep 'default_version' $(EXTENSION).control | head -1 | sed -e $(SHORTVER_MATCHER))
+EXT_LONGVER = $(shell grep '"version":' META.json | head -1 \
+	| sed -e 's/[[:space:]]*"version":[[:space:]]*"\(.*\)",/\1/')
+EXT_SHORTVER = $(shell grep 'default_version' $(EXTENSION).control | head -1 \
+	| sed -e "s/default_version[[:space:]]*=[[:space:]]'\(.*\)'/\1/")
 
 SRC_C = $(sort $(wildcard src/*.c))
 SRC_H = $(sort $(wildcard src/*.h))

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,17 @@ EXTENSION = pgmp
 MODULEDIR = $(EXTENSION)
 MODULE_big = $(EXTENSION)
 
-EXT_LONGVER = $(shell grep '"version":' META.json | head -1 | sed -e 's/\s*"version":\s*"\(.*\)",/\1/')
-EXT_SHORTVER = $(shell grep 'default_version' $(EXTENSION).control | head -1 | sed -e "s/default_version\s*=\s'\(.*\)'/\1/")
+ifeq ($(shell sed --version 2>/dev/null | grep -q GNU && echo gnu),gnu)
+	LONGVER_MATCHER = 's/\s*"version":\s*"\(.*\)",/\1/'
+	SHORTVER_MATCHER = "s/default_version\s*=\s'\(.*\)'/\1/"
+else
+  # Adapt syntax for POSIX (FreeBSD)
+	LONGVER_MATCHER = 's/[[:space:]]*"version":[[:space:]]*"\(.*\)",/\1/'
+	SHORTVER_MATCHER = "s/default_version[[:space:]]*=[[:space:]]'\(.*\)'/\1/"
+endif
+
+EXT_LONGVER = $(shell grep '"version":' META.json | head -1 | sed -e $(LONGVER_MATCHER))
+EXT_SHORTVER = $(shell grep 'default_version' $(EXTENSION).control | head -1 | sed -e $(SHORTVER_MATCHER))
 
 SRC_C = $(sort $(wildcard src/*.c))
 SRC_H = $(sort $(wildcard src/*.h))


### PR DESCRIPTION
Hi there Daniele, long time uh?? Miss our barbecues in Acton Town back in the day! :D

I started using this very helpful extension on a personal project and was amazed to find out you were the author. Small world.

Anyway, I had the same problem as described in #20, went ahead and added a small workaround for adapting the `sed` syntax and was able to compile it in Mac OS without any issues.

Differently from #20, the tests seem to be passing.  Not sure why, but I hope this is helpful.

Cheers!