### PR TITLE
Fix regression tests against PostgreSQL 19 and also fix build warnings

### DIFF
--- a/src/pgmp-impl.h
+++ b/src/pgmp-impl.h
@@ -54,6 +54,15 @@
  */
 #define PGMP_MAX_HDRSIZE 8
 
+/* A couple of constant limbs used to create constant mp? data
+ * from the content of varlena data.
+ *
+ * Defined in pgmp.c: declared here so that every translation unit
+ * (including the one defining them) sees a prior declaration, as
+ * required by -Wmissing-variable-declarations. */
+extern const mp_limb_t _pgmp_limb_0;
+extern const mp_limb_t _pgmp_limb_1;
+
 /*
  * Macros equivalent to the ones defimed in gmp-impl.h
  */

--- a/src/pmpq.c
+++ b/src/pmpq.c
@@ -25,11 +25,6 @@
 #include "fmgr.h"
 
 
-/* To be referred to to represent the zero */
-extern const mp_limb_t _pgmp_limb_0;
-extern const mp_limb_t _pgmp_limb_1;
-
-
 /*
  * Create a pmpq structure from the content of a mpq
  *

--- a/src/pmpq_agg.c
+++ b/src/pmpq_agg.c
@@ -48,7 +48,7 @@ PGMP_PG_FUNCTION(_pmpq_from_agg)
 PGMP_PG_FUNCTION(_pmpq_agg_ ## op) \
 { \
     mpq_t           *a; \
-    const mpq_t     q; \
+    const mpq_t     q = {0}; \
     MemoryContext   oldctx; \
     MemoryContext   aggctx; \
  \

--- a/src/pmpq_arith.c
+++ b/src/pmpq_arith.c
@@ -48,7 +48,7 @@ PGMP_PG_FUNCTION(pmpq_uplus)
  \
 PGMP_PG_FUNCTION(pmpq_ ## op) \
 { \
-    const mpq_t     q; \
+    const mpq_t     q = {0}; \
     mpq_t           qf; \
  \
     PGMP_GETARG_MPQ(q, 0); \
@@ -75,8 +75,8 @@ PMPQ_UN(inv, PMPQ_CHECK_DIV0)
  \
 PGMP_PG_FUNCTION(pmpq_ ## op) \
 { \
-    const mpq_t     q1; \
-    const mpq_t     q2; \
+    const mpq_t     q1 = {0}; \
+    const mpq_t     q2 = {0}; \
     mpq_t           qf; \
  \
     PGMP_GETARG_MPQ(q1, 0); \
@@ -101,7 +101,7 @@ PMPQ_OP(div, PMPQ_CHECK_DIV0)
  \
 PGMP_PG_FUNCTION(pmpq_ ## op) \
 { \
-    const mpq_t     q; \
+    const mpq_t     q = {0}; \
     unsigned long   b; \
     mpq_t           qf; \
  \
@@ -125,8 +125,8 @@ PMPQ_BIT(div_2exp)
 
 PGMP_PG_FUNCTION(pmpq_cmp)
 {
-    const mpq_t     q1;
-    const mpq_t     q2;
+    const mpq_t     q1 = {0};
+    const mpq_t     q2 = {0};
 
     PGMP_GETARG_MPQ(q1, 0);
     PGMP_GETARG_MPQ(q2, 1);
@@ -139,8 +139,8 @@ PGMP_PG_FUNCTION(pmpq_cmp)
  \
 PGMP_PG_FUNCTION(pmpq_ ## op) \
 { \
-    const mpq_t     q1; \
-    const mpq_t     q2; \
+    const mpq_t     q1 = {0}; \
+    const mpq_t     q2 = {0}; \
  \
     PGMP_GETARG_MPQ(q1, 0); \
     PGMP_GETARG_MPQ(q2, 1); \
@@ -156,8 +156,8 @@ PMPQ_CMP_EQ(ne, ==)
  \
 PGMP_PG_FUNCTION(pmpq_ ## op) \
 { \
-    const mpq_t     q1; \
-    const mpq_t     q2; \
+    const mpq_t     q1 = {0}; \
+    const mpq_t     q2 = {0}; \
  \
     PGMP_GETARG_MPQ(q1, 0); \
     PGMP_GETARG_MPQ(q2, 1); \
@@ -176,7 +176,7 @@ PMPQ_CMP(le, <=)
  */
 PGMP_PG_FUNCTION(pmpq_hash)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     Datum           nhash;
 
     PGMP_GETARG_MPQ(q, 0);
@@ -200,8 +200,8 @@ static void limit_den(mpq_ptr q_out, mpq_srcptr q_in, mpz_srcptr max_den);
 
 PGMP_PG_FUNCTION(pmpq_limit_den)
 {
-    const mpq_t     q_in;
-    const mpz_t     max_den;
+    const mpq_t     q_in = {0};
+    const mpz_t     max_den = {0};
     mpq_t           q_out;
 
     PGMP_GETARG_MPQ(q_in, 0);

--- a/src/pmpq_io.c
+++ b/src/pmpq_io.c
@@ -94,7 +94,7 @@ PGMP_PG_FUNCTION(pmpq_in_base)
 
 PGMP_PG_FUNCTION(pmpq_out)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     char            *buf;
 
     PGMP_GETARG_MPQ(q, 0);
@@ -109,7 +109,7 @@ PGMP_PG_FUNCTION(pmpq_out)
 
 PGMP_PG_FUNCTION(pmpq_out_base)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     int             base;
     char            *buf;
 
@@ -276,7 +276,7 @@ PGMP_PG_FUNCTION(pmpq_from_mpz)
 
 PGMP_PG_FUNCTION(pmpq_to_mpz)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     mpz_t           z;
 
     PGMP_GETARG_MPQ(q, 0);
@@ -293,7 +293,7 @@ Datum pmpz_to_ ## type (PG_FUNCTION_ARGS); \
  \
 PGMP_PG_FUNCTION(pmpq_to_ ## type) \
 { \
-    const mpq_t     q; \
+    const mpq_t     q = {0}; \
     mpz_t           z; \
  \
     PGMP_GETARG_MPQ(q, 0); \
@@ -311,7 +311,7 @@ PMPQ_TO_INT(int8)
 
 PGMP_PG_FUNCTION(pmpq_to_float4)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     PGMP_GETARG_MPQ(q, 0);
 
     PG_RETURN_FLOAT4((float4)mpq_get_d(q));
@@ -319,7 +319,7 @@ PGMP_PG_FUNCTION(pmpq_to_float4)
 
 PGMP_PG_FUNCTION(pmpq_to_float8)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     PGMP_GETARG_MPQ(q, 0);
 
     PG_RETURN_FLOAT8((float8)mpq_get_d(q));
@@ -328,7 +328,7 @@ PGMP_PG_FUNCTION(pmpq_to_float8)
 
 PGMP_PG_FUNCTION(pmpq_to_numeric)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     int32           typmod;
     long            scale;
     mpz_t           z;
@@ -426,8 +426,8 @@ PGMP_PG_FUNCTION(pmpq_to_numeric)
 
 PGMP_PG_FUNCTION(pmpq_mpz_mpz)
 {
-    const mpz_t     num;
-    const mpz_t     den;
+    const mpz_t     num = {0};
+    const mpz_t     den = {0};
     mpq_t           q;
 
     /* We must take a copy of num and den because they may be modified by
@@ -491,7 +491,7 @@ PGMP_PG_FUNCTION(pmpq_numeric_numeric)
 
 PGMP_PG_FUNCTION(pmpq_num)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     mpz_t           z;
 
     PGMP_GETARG_MPQ(q, 0);
@@ -503,7 +503,7 @@ PGMP_PG_FUNCTION(pmpq_num)
 
 PGMP_PG_FUNCTION(pmpq_den)
 {
-    const mpq_t     q;
+    const mpq_t     q = {0};
     mpz_t           z;
 
     PGMP_GETARG_MPQ(q, 0);

--- a/src/pmpz.c
+++ b/src/pmpz.c
@@ -25,10 +25,6 @@
 #include "fmgr.h"
 
 
-/* To be referred to to represent the zero */
-extern const mp_limb_t _pgmp_limb_0;
-
-
 /*
  * Create a pmpz structure from the content of a mpz.
  *

--- a/src/pmpz_agg.c
+++ b/src/pmpz_agg.c
@@ -48,7 +48,7 @@ PGMP_PG_FUNCTION(_pmpz_from_agg)
 PGMP_PG_FUNCTION(_pmpz_agg_ ## op) \
 { \
     mpz_t           *a; \
-    const mpz_t     z; \
+    const mpz_t     z = {0}; \
     MemoryContext   oldctx; \
     MemoryContext   aggctx; \
  \

--- a/src/pmpz_arith.c
+++ b/src/pmpz_arith.c
@@ -55,7 +55,7 @@ PGMP_PG_FUNCTION(pmpz_uplus)
  \
 PGMP_PG_FUNCTION(pmpz_ ## op) \
 { \
-    const mpz_t     z1; \
+    const mpz_t     z1 = {0}; \
     mpz_t           zf; \
  \
     PGMP_GETARG_MPZ(z1, 0); \
@@ -86,8 +86,8 @@ PMPZ_UN(com,    PMPZ_NO_CHECK)
  \
 PGMP_PG_FUNCTION(pmpz_ ## op) \
 { \
-    const mpz_t     z1; \
-    const mpz_t     z2; \
+    const mpz_t     z1 = {0}; \
+    const mpz_t     z2 = {0}; \
     mpz_t           zf; \
  \
     PGMP_GETARG_MPZ(z1, 0); \
@@ -124,8 +124,8 @@ PMPZ_OP(remove,     PMPZ_NO_CHECK)      /* TODO: return value not returned */
  \
 PGMP_PG_FUNCTION(pmpz_ ## op) \
 { \
-    const mpz_t     z1; \
-    const mpz_t     z2; \
+    const mpz_t     z1 = {0}; \
+    const mpz_t     z2 = {0}; \
     mpz_t           zf1; \
     mpz_t           zf2; \
  \
@@ -151,7 +151,7 @@ PMPZ_OP2(fdiv_qr,    PMPZ_CHECK_DIV0)
  \
 PGMP_PG_FUNCTION(pmpz_ ## op) \
 { \
-    const mpz_t     z; \
+    const mpz_t     z = {0}; \
     unsigned long   b; \
     mpz_t           zf; \
  \
@@ -194,7 +194,7 @@ PMPZ_OP_BITCNT(fdiv_r_2exp,     PMPZ_NO_CHECK,  PMPZ_NO_CHECK)
  \
 PGMP_PG_FUNCTION(pmpz_ ## pred) \
 { \
-    const mpz_t     op; \
+    const mpz_t     op = {0}; \
  \
     PGMP_GETARG_MPZ(op, 0); \
  \
@@ -213,8 +213,8 @@ PMPZ_PRED(perfect_square)
 
 PGMP_PG_FUNCTION(pmpz_cmp)
 {
-    const mpz_t     z1;
-    const mpz_t     z2;
+    const mpz_t     z1 = {0};
+    const mpz_t     z2 = {0};
 
     PGMP_GETARG_MPZ(z1, 0);
     PGMP_GETARG_MPZ(z2, 1);
@@ -227,8 +227,8 @@ PGMP_PG_FUNCTION(pmpz_cmp)
  \
 PGMP_PG_FUNCTION(pmpz_ ## op) \
 { \
-    const mpz_t     z1; \
-    const mpz_t     z2; \
+    const mpz_t     z1 = {0}; \
+    const mpz_t     z2 = {0}; \
  \
     PGMP_GETARG_MPZ(z1, 0); \
     PGMP_GETARG_MPZ(z2, 1); \
@@ -249,7 +249,7 @@ PMPZ_CMP(le, <=)
  */
 PGMP_PG_FUNCTION(pmpz_hash)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
 
     PGMP_GETARG_MPZ(z, 0);
     return pmpz_get_hash(z);
@@ -276,7 +276,7 @@ pmpz_get_hash(mpz_srcptr z)
 
 PGMP_PG_FUNCTION(pmpz_sgn)
 {
-    const mpz_t     n;
+    const mpz_t     n = {0};
 
     PGMP_GETARG_MPZ(n, 0);
 
@@ -285,8 +285,8 @@ PGMP_PG_FUNCTION(pmpz_sgn)
 
 PGMP_PG_FUNCTION(pmpz_divisible)
 {
-    const mpz_t     n;
-    const mpz_t     d;
+    const mpz_t     n = {0};
+    const mpz_t     d = {0};
 
     PGMP_GETARG_MPZ(n, 0);
     PGMP_GETARG_MPZ(d, 1);
@@ -303,7 +303,7 @@ PGMP_PG_FUNCTION(pmpz_divisible)
 
 PGMP_PG_FUNCTION(pmpz_divisible_2exp)
 {
-    const mpz_t     n;
+    const mpz_t     n = {0};
     mp_bitcnt_t     b;
 
     PGMP_GETARG_MPZ(n, 0);
@@ -314,9 +314,9 @@ PGMP_PG_FUNCTION(pmpz_divisible_2exp)
 
 PGMP_PG_FUNCTION(pmpz_congruent)
 {
-    const mpz_t     n;
-    const mpz_t     c;
-    const mpz_t     d;
+    const mpz_t     n = {0};
+    const mpz_t     c = {0};
+    const mpz_t     d = {0};
 
     PGMP_GETARG_MPZ(n, 0);
     PGMP_GETARG_MPZ(c, 1);
@@ -335,8 +335,8 @@ PGMP_PG_FUNCTION(pmpz_congruent)
 
 PGMP_PG_FUNCTION(pmpz_congruent_2exp)
 {
-    const mpz_t     n;
-    const mpz_t     c;
+    const mpz_t     n = {0};
+    const mpz_t     c = {0};
     mp_bitcnt_t     b;
 
     PGMP_GETARG_MPZ(n, 0);
@@ -349,9 +349,9 @@ PGMP_PG_FUNCTION(pmpz_congruent_2exp)
 
 PGMP_PG_FUNCTION(pmpz_powm)
 {
-    const mpz_t     base;
-    const mpz_t     exp;
-    const mpz_t     mod;
+    const mpz_t     base = {0};
+    const mpz_t     exp = {0};
+    const mpz_t     mod = {0};
     mpz_t           zf;
 
     PGMP_GETARG_MPZ(base, 0);

--- a/src/pmpz_bits.c
+++ b/src/pmpz_bits.c
@@ -72,7 +72,7 @@ PGMP_PG_FUNCTION(pgmp_max_bitcnt)
 
 PGMP_PG_FUNCTION(pmpz_popcount)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     mp_bitcnt_t     ret;
 
     PGMP_GETARG_MPZ(z, 0);
@@ -83,8 +83,8 @@ PGMP_PG_FUNCTION(pmpz_popcount)
 
 PGMP_PG_FUNCTION(pmpz_hamdist)
 {
-    const mpz_t     z1;
-    const mpz_t     z2;
+    const mpz_t     z1 = {0};
+    const mpz_t     z2 = {0};
     mp_bitcnt_t     ret;
 
     PGMP_GETARG_MPZ(z1, 0);
@@ -99,7 +99,7 @@ PGMP_PG_FUNCTION(pmpz_hamdist)
  \
 PGMP_PG_FUNCTION(pmpz_ ## f) \
 { \
-    const mpz_t     z; \
+    const mpz_t     z = {0}; \
     mp_bitcnt_t     start; \
  \
     PGMP_GETARG_MPZ(z, 0); \
@@ -118,7 +118,7 @@ PMPZ_SCAN(scan1)
  \
 PGMP_PG_FUNCTION(pmpz_ ## f) \
 { \
-    const mpz_t     z; \
+    const mpz_t     z = {0}; \
     mp_bitcnt_t     idx; \
     mpz_t           ret; \
  \
@@ -140,7 +140,7 @@ PMPZ_BIT(combit)
 
 PGMP_PG_FUNCTION(pmpz_tstbit)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     mp_bitcnt_t     idx;
     int32           ret;
 

--- a/src/pmpz_io.c
+++ b/src/pmpz_io.c
@@ -89,7 +89,7 @@ PGMP_PG_FUNCTION(pmpz_in_base)
 
 PGMP_PG_FUNCTION(pmpz_out)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     char            *buf;
 
     PGMP_GETARG_MPZ(z, 0);
@@ -105,7 +105,7 @@ PGMP_PG_FUNCTION(pmpz_out)
 
 PGMP_PG_FUNCTION(pmpz_out_base)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     int             base;
     char            *buf;
 
@@ -266,7 +266,7 @@ PGMP_PG_FUNCTION(pmpz_from_numeric)
 
 PGMP_PG_FUNCTION(pmpz_to_int2)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     int16           out;
 
     PGMP_GETARG_MPZ(z, 0);
@@ -283,7 +283,7 @@ PGMP_PG_FUNCTION(pmpz_to_int2)
 
 PGMP_PG_FUNCTION(pmpz_to_int4)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     int32           out;
 
     PGMP_GETARG_MPZ(z, 0);
@@ -300,7 +300,7 @@ PGMP_PG_FUNCTION(pmpz_to_int4)
 
 PGMP_PG_FUNCTION(pmpz_to_int8)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     int64           ret = 0;
 
     PGMP_GETARG_MPZ(z, 0);
@@ -372,7 +372,7 @@ pmpz_get_int64(mpz_srcptr z, int64 *out)
 
 PGMP_PG_FUNCTION(pmpz_to_float4)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     double          out;
 
     PGMP_GETARG_MPZ(z, 0);
@@ -382,7 +382,7 @@ PGMP_PG_FUNCTION(pmpz_to_float4)
 
 PGMP_PG_FUNCTION(pmpz_to_float8)
 {
-    const mpz_t     z;
+    const mpz_t     z = {0};
     double          out;
 
     PGMP_GETARG_MPZ(z, 0);

--- a/src/pmpz_rand.c
+++ b/src/pmpz_rand.c
@@ -33,7 +33,7 @@
  * TODO: check if there is a way to explicitly allocate this structure per
  * session.
  */
-gmp_randstate_t     *pgmp_randstate;
+static gmp_randstate_t     *pgmp_randstate;
 
 
 /* Clear the random state if set
@@ -102,7 +102,7 @@ PGMP_RANDINIT(randinit_mt,      PGMP_RANDINIT_NOARG)
 
 #define PGMP_RANDINIT_ACE(f) \
 do { \
-    const mpz_t         a; \
+    const mpz_t         a = {0}; \
     unsigned long       c; \
     mp_bitcnt_t         e; \
  \
@@ -135,7 +135,7 @@ PGMP_RANDINIT(randinit_lc_2exp_size, PGMP_RANDINIT_SIZE)
 
 PGMP_PG_FUNCTION(pgmp_randseed)
 {
-    const mpz_t         seed;
+    const mpz_t         seed = {0};
     MemoryContext       oldctx;
 
     PGMP_CHECK_RANDSTATE;
@@ -179,7 +179,7 @@ PMPZ_RAND_BITCNT(rrandomb)
 
 PGMP_PG_FUNCTION(pmpz_urandomm)
 {
-    const mpz_t     n;
+    const mpz_t     n = {0};
     mpz_t           ret;
 
     PGMP_CHECK_RANDSTATE;

--- a/src/pmpz_roots.c
+++ b/src/pmpz_roots.c
@@ -33,7 +33,7 @@
 
 PGMP_PG_FUNCTION(pmpz_rootrem)
 {
-    const mpz_t     z1;
+    const mpz_t     z1 = {0};
     mpz_t           zroot;
     mpz_t           zrem;
     unsigned long   n;
@@ -55,7 +55,7 @@ PGMP_PG_FUNCTION(pmpz_rootrem)
 
 PGMP_PG_FUNCTION(pmpz_sqrtrem)
 {
-    const mpz_t     z1;
+    const mpz_t     z1 = {0};
     mpz_t           zroot;
     mpz_t           zrem;
 

--- a/src/pmpz_theor.c
+++ b/src/pmpz_theor.c
@@ -31,7 +31,7 @@
 
 PGMP_PG_FUNCTION(pmpz_probab_prime_p)
 {
-    const mpz_t     z1;
+    const mpz_t     z1 = {0};
     int             reps;
 
     PGMP_GETARG_MPZ(z1, 0);
@@ -42,7 +42,7 @@ PGMP_PG_FUNCTION(pmpz_probab_prime_p)
 
 PGMP_PG_FUNCTION(pmpz_nextprime)
 {
-    const mpz_t     z1;
+    const mpz_t     z1 = {0};
     mpz_t           zf;
 
     PGMP_GETARG_MPZ(z1, 0);
@@ -65,8 +65,8 @@ PGMP_PG_FUNCTION(pmpz_nextprime)
 
 PGMP_PG_FUNCTION(pmpz_gcdext)
 {
-    const mpz_t     z1;
-    const mpz_t     z2;
+    const mpz_t     z1 = {0};
+    const mpz_t     z2 = {0};
     mpz_t           zf;
     mpz_t           zs;
     mpz_t           zt;
@@ -84,8 +84,8 @@ PGMP_PG_FUNCTION(pmpz_gcdext)
 
 PGMP_PG_FUNCTION(pmpz_invert)
 {
-    const mpz_t     z1;
-    const mpz_t     z2;
+    const mpz_t     z1 = {0};
+    const mpz_t     z2 = {0};
     mpz_t           zf;
     int             ret;
 
@@ -108,8 +108,8 @@ PGMP_PG_FUNCTION(pmpz_invert)
  \
 PGMP_PG_FUNCTION(pmpz_ ## f) \
 { \
-    const mpz_t     z1; \
-    const mpz_t     z2; \
+    const mpz_t     z1 = {0}; \
+    const mpz_t     z2 = {0}; \
  \
     PGMP_GETARG_MPZ(z1, 0); \
     PGMP_GETARG_MPZ(z2, 1); \

--- a/test/expected/mpq_1.out
+++ b/test/expected/mpq_1.out
@@ -1,0 +1,537 @@
+--
+--  Test mpq datatype
+--
+-- Compact output
+\t
+\a
+--
+-- mpq input and output functions
+--
+SELECT '0'::mpq;
+0
+SELECT '1'::mpq;
+1
+SELECT '-1'::mpq;
+-1
+SELECT '10'::mpq;
+10
+SELECT '-10'::mpq;
+-10
+SELECT '4294967295'::mpq;   -- limbs boundaries
+4294967295
+SELECT '4294967296'::mpq;
+4294967296
+SELECT '-4294967296'::mpq;
+-4294967296
+SELECT '-4294967297'::mpq;
+-4294967297
+SELECT '18446744073709551614'::mpq;
+18446744073709551614
+SELECT '18446744073709551615'::mpq;
+18446744073709551615
+SELECT '18446744073709551616'::mpq;
+18446744073709551616
+SELECT '18446744073709551617'::mpq;
+18446744073709551617
+SELECT '-18446744073709551615'::mpq;
+-18446744073709551615
+SELECT '-18446744073709551616'::mpq;
+-18446744073709551616
+SELECT '-18446744073709551617'::mpq;
+-18446744073709551617
+SELECT '-18446744073709551618'::mpq;
+-18446744073709551618
+SELECT '12345678901234567890123456789012345678901234567890123456789012345678901234567890'::mpq;
+12345678901234567890123456789012345678901234567890123456789012345678901234567890
+SELECT '-12345678901234567890123456789012345678901234567890123456789012345678901234567890'::mpq;
+-12345678901234567890123456789012345678901234567890123456789012345678901234567890
+SELECT '1/4294967295'::mpq;   -- limbs boundaries on denom
+1/4294967295
+SELECT '1/4294967296'::mpq;
+1/4294967296
+SELECT '-1/4294967296'::mpq;
+-1/4294967296
+SELECT '-1/4294967297'::mpq;
+-1/4294967297
+SELECT '1/18446744073709551614'::mpq;
+1/18446744073709551614
+SELECT '1/18446744073709551615'::mpq;
+1/18446744073709551615
+SELECT '1/18446744073709551616'::mpq;
+1/18446744073709551616
+SELECT '1/18446744073709551617'::mpq;
+1/18446744073709551617
+SELECT '-1/18446744073709551615'::mpq;
+-1/18446744073709551615
+SELECT '-1/18446744073709551616'::mpq;
+-1/18446744073709551616
+SELECT '-1/18446744073709551617'::mpq;
+-1/18446744073709551617
+SELECT '-1/18446744073709551618'::mpq;
+-1/18446744073709551618
+SELECT '1/12345678901234567890123456789012345678901234567890123456789012345678901234567890'::mpq;
+1/12345678901234567890123456789012345678901234567890123456789012345678901234567890
+SELECT '-1/12345678901234567890123456789012345678901234567890123456789012345678901234567890'::mpq;
+-1/12345678901234567890123456789012345678901234567890123456789012345678901234567890
+SELECT '1/1'::mpq;
+1
+SELECT '2/3'::mpq;
+2/3
+SELECT '640/30'::mpq;
+64/3
+SELECT '-640/30'::mpq;
+-64/3
+SELECT '18446744073709551616/18446744073709551616'::mpq;
+1
+SELECT '12345678901234567890123456789012345678901234567890123456789012345678901234567890/'
+       '88888888888888888888888888888888888888888888888888888888888888888888888888888888'::mpq;
+617283945/4444444444
+SELECT '1/0'::mpq;
+ERROR:  denominator can't be zero
+LINE 1: SELECT '1/0'::mpq;
+               ^
+SELECT mpq('1/1');
+1
+SELECT mpq('2/3');
+2/3
+SELECT mpq('640/30');
+64/3
+SELECT mpq('-640/30');
+-64/3
+SELECT mpq('0xEF/100');
+239/100
+SELECT mpq('0xEF/0x100');
+239/256
+SELECT mpq('10/30', 10);
+1/3
+SELECT mpq('EF/100', 16);
+239/256
+SELECT mpq('0xEF/100', 0);
+239/100
+SELECT mpq('z', 36), mpq('Z', 36);
+35|35
+SELECT mpq('z', 62), mpq('Z', 62);
+61|35
+SELECT mpq('1', 1);
+ERROR:  invalid base for mpq input: 1
+HINT:  base should be between 2 and 62
+SELECT mpq('1', -10);
+ERROR:  invalid base for mpq input: -10
+HINT:  base should be between 2 and 62
+SELECT mpq('1', 63);
+ERROR:  invalid base for mpq input: 63
+HINT:  base should be between 2 and 62
+SELECT text('239'::mpq);
+239
+SELECT text('-239'::mpq);
+-239
+SELECT text('239/256'::mpq);
+239/256
+SELECT text('239'::mpq, 16);
+ef
+SELECT text('239/256'::mpq, 10);
+239/256
+SELECT text('239/256'::mpq, 16);
+ef/100
+SELECT text('239/256'::mpq, 0);
+ERROR:  invalid base for mpq output: 0
+HINT:  base should be between -36 and -2 or between 2 and 62
+SELECT text('239/256'::mpq, 1);
+ERROR:  invalid base for mpq output: 1
+HINT:  base should be between -36 and -2 or between 2 and 62
+SELECT text('239/256'::mpq, 2);
+11101111/100000000
+SELECT text('239/256'::mpq, 36);
+6n/74
+SELECT text('239/256'::mpq, 62);
+3r/48
+SELECT text('239/256'::mpq, 63);
+ERROR:  invalid base for mpq output: 63
+HINT:  base should be between -36 and -2 or between 2 and 62
+SELECT text('239/256'::mpq, -1);
+ERROR:  invalid base for mpq output: -1
+HINT:  base should be between -36 and -2 or between 2 and 62
+SELECT text('239/256'::mpq, -2);
+11101111/100000000
+SELECT text('239/256'::mpq, -36);
+6N/74
+SELECT text('239/256'::mpq, -37);
+ERROR:  invalid base for mpq output: -37
+HINT:  base should be between -36 and -2 or between 2 and 62
+--
+-- mpq cast
+--
+SELECT 0::smallint::mpq, (-32768)::smallint::mpq, 32767::smallint::mpq;
+0|-32768|32767
+SELECT 0::integer::mpq, (-2147483648)::integer::mpq, 2147483647::integer::mpq;
+0|-2147483648|2147483647
+SELECT 0::bigint::mpq, (-9223372036854775808)::bigint::mpq, 9223372036854775807::bigint::mpq;
+0|-9223372036854775808|9223372036854775807
+SELECT 0::numeric::mpq, (-12345678901234567890)::numeric::mpq, 12345678901234567890::numeric::mpq;
+0|-12345678901234567890|12345678901234567890
+SELECT 0::mpz::mpq, (-12345678901234567890)::mpz::mpq, 12345678901234567890::mpz::mpq;
+0|-12345678901234567890|12345678901234567890
+SELECT 0.0::float4::mpq, (-12345.25)::float4::mpq, 12345.25::float4::mpq;
+0|-49381/4|49381/4
+SELECT 0.0::float8::mpq, (-123456789012.25)::float8::mpq, 123456789012.25::float8::mpq;
+0|-493827156049/4|493827156049/4
+SELECT 0.1::float4::mpq;    -- don't know if it's portable
+13421773/134217728
+SELECT 0.1::float8::mpq;
+3602879701896397/36028797018963968
+SELECT 0.0::numeric::mpq, (-1234567890.12345)::numeric::mpq, 1234567890.12345::numeric::mpq;
+0|-24691357802469/20000|24691357802469/20000
+SELECT 0::mpq, 1::mpq, (-1)::mpq;       -- automatic casts
+0|1|-1
+SELECT 1000000::mpq, (-1000000)::mpq;
+1000000|-1000000
+SELECT 1000000000::mpq, (-1000000000)::mpq;
+1000000000|-1000000000
+SELECT 1000000000000000::mpq, (-1000000000000000)::mpq;
+1000000000000000|-1000000000000000
+SELECT 1000000000000000000000000000000::mpq, (-1000000000000000000000000000000)::mpq;
+1000000000000000000000000000000|-1000000000000000000000000000000
+SELECT 0.0::mpq, (-1234567890.12345)::mpq, 1234567890.12345::mpq;
+0|-24691357802469/20000|24691357802469/20000
+SELECT 'NaN'::decimal::mpq;
+ERROR:  can't convert numeric value to mpq: "NaN"
+SELECT -1::mpq;       -- these take the unary minus to work
+-1
+SELECT -1000000::mpq;
+-1000000
+SELECT -1000000000::mpq;
+-1000000000
+SELECT -1000000000000000::mpq;
+-1000000000000000
+SELECT -1000000000000000000000000000000::mpq;
+-1000000000000000000000000000000
+SELECT 123.10::mpq::mpz, (-123.10)::mpq::mpz;
+123|-123
+SELECT 123.90::mpq::mpz, (-123.90)::mpq::mpz;
+123|-123
+SELECT 123.10::mpq::int2, (-123.10)::mpq::int2;
+123|-123
+SELECT 123.10::mpq::int4, (-123.10)::mpq::int4;
+123|-123
+SELECT 123.10::mpq::int8, (-123.10)::mpq::int8;
+123|-123
+SELECT 32767::mpq::int2;
+32767
+SELECT 32768::mpq::int2;
+ERROR:  numeric value too big to be converted to int2 data type
+SELECT (-32768)::mpq::int2;
+-32768
+SELECT (-32769)::mpq::int2;
+ERROR:  numeric value too big to be converted to int2 data type
+SELECT 2147483647::mpq::int4;
+2147483647
+SELECT 2147483648::mpq::int4;
+ERROR:  numeric value too big to be converted to int4 data type
+SELECT (-2147483648)::mpq::int4;
+-2147483648
+SELECT (-2147483649)::mpq::int4;
+ERROR:  numeric value too big to be converted to int4 data type
+SELECT 9223372036854775807::mpq::int8;
+9223372036854775807
+SELECT 9223372036854775808::mpq::int8;
+ERROR:  numeric value too big to be converted to int8 data type
+SELECT (-9223372036854775808)::mpq::int8;
+-9223372036854775808
+SELECT (-9223372036854775809)::mpq::int8;
+ERROR:  numeric value too big to be converted to int8 data type
+SELECT 123.10::mpq::float4, (-123.10)::mpq::float4;
+123.1|-123.1
+SELECT 123.10::mpq::float8, (-123.10)::mpq::float8;
+123.1|-123.1
+SELECT pow(10::mpz,400)::mpq::float4;       -- +inf
+Infinity
+SELECT (-pow(10::mpz,400))::mpq::float4;    -- -inf
+-Infinity
+SELECT mpq(1,pow(10::mpz,400))::float4;     -- underflow
+0
+SELECT pow(10::mpz,400)::mpq::float8;
+Infinity
+SELECT (-pow(10::mpz,400))::mpq::float8;
+-Infinity
+SELECT mpq(1,pow(10::mpz,400))::float8;
+0
+SELECT 1::mpq::numeric;
+1
+SELECT 123.456::mpq::numeric;
+123.456
+SELECT 123.456::mpq::numeric(10);
+123
+SELECT 123.456::mpq::numeric(10,2);
+123.45
+SELECT mpq(4,3)::numeric;
+1.333333333333333
+SELECT mpq(4,3)::numeric(10);
+1
+SELECT mpq(4,3)::numeric(10,5);
+1.33333
+SELECT mpq(40000,3)::numeric(10,5);
+13333.33333
+SELECT mpq(-40000,3)::numeric(10,5);
+-13333.33333
+SELECT mpq(400000,3)::numeric(10,5);
+ERROR:  numeric field overflow
+DETAIL:  A field with precision 10, scale 5 must round to an absolute value less than 10^5.
+-- function-style casts
+SELECT mpq('0'::varchar);
+0
+SELECT mpq('0'::int2);
+0
+SELECT mpq('0'::int4);
+0
+SELECT mpq('0'::int8);
+0
+SELECT mpq('0'::float4);
+0
+SELECT mpq('0'::float8);
+0
+SELECT mpq('0'::numeric);
+0
+SELECT mpq('0'::mpz);
+0
+SELECT text(0::mpq);
+0
+SELECT int2(0::mpq);
+0
+SELECT int4(0::mpq);
+0
+SELECT int8(0::mpq);
+0
+SELECT float4(0::mpq);
+0
+SELECT float8(0::mpq);
+0
+SELECT mpz('0'::mpq);
+0
+-- tricky cases of cast to numeric
+select (x::mpz::mpq / 100)::decimal      from generate_series(-2, 2) x;
+-0.02
+-0.01
+0
+0.01
+0.02
+select (x::mpz::mpq / 100)::decimal(6,0) from generate_series(-2, 2) x;
+0
+0
+0
+0
+0
+select (x::mpz::mpq / 100)::decimal(6,1) from generate_series(-2, 2) x;
+0.0
+0.0
+0.0
+0.0
+0.0
+select (x::mpz::mpq / 100)::decimal(6,2) from generate_series(-2, 2) x;
+-0.02
+-0.01
+0.00
+0.01
+0.02
+SELECT mpq(10, 4), mpq(10, -4);
+5/2|-5/2
+SELECT mpq(10, 0);
+ERROR:  denominator can't be zero
+-- fails if mpq(int, int) or similar are availiable
+SELECT mpq(4000000000000000000,3);
+4000000000000000000/3
+-- TODO: this shoud work.
+-- currently not accepting it for ambiguous type promotion problems,
+-- but this could change in the future if we find how to fix the above problem
+SELECT mpq(47563485764385764395874365986384, 874539847539845639485769837553465);
+ERROR:  function mpq(numeric, numeric) does not exist
+LINE 1: SELECT mpq(47563485764385764395874365986384, 874539847539845...
+               ^
+DETAIL:  No function of that name accepts the given argument types.
+HINT:  You might need to add explicit type casts.
+-- Enable these checks if the above is solved.
+-- SELECT mpq(1230::numeric, 123::numeric);
+-- SELECT mpq(123.45::numeric, 1::numeric);
+-- SELECT mpq(1::numeric, 123.45::numeric);
+-- SELECT mpq(123::numeric, 0::numeric);
+SELECT mpq(47563485764385764395874365986384::mpz, 874539847539845639485769837553465::mpz);
+15854495254795254798624788662128/291513282513281879828589945851155
+SELECT mpq('10'::mpz, '0'::mpz);
+ERROR:  denominator can't be zero
+SELECT num('4/5'::mpq);
+4
+SELECT den('4/5'::mpq);
+5
+--
+-- mpq arithmetic
+--
+SELECT -('0'::mpq), +('0'::mpq), -('1'::mpq), +('1'::mpq), -('-1'::mpq), +('-1'::mpq);
+0|0|-1|1|1|-1
+SELECT -('1234567890123456/7890'::mpq), +('1234567890123456/7890'::mpq);
+-205761315020576/1315|205761315020576/1315
+SELECT '4/5'::mpq + '6/8'::mpq;
+31/20
+SELECT '4/5'::mpq - '6/8'::mpq;
+1/20
+SELECT '4/5'::mpq * '6/8'::mpq;
+3/5
+SELECT '4/5'::mpq / '6/8'::mpq;
+16/15
+SELECT '4/5'::mpq / '0'::mpq;
+ERROR:  division by zero
+SELECT '4/5'::mpq << 4;
+64/5
+SELECT '4/5'::mpq << -1;
+ERROR:  argument can't be negative
+SELECT '4/5'::mpq >> 4;
+1/20
+SELECT '4/5'::mpq >> -1;
+ERROR:  argument can't be negative
+--
+-- mpq unary function
+--
+SELECT abs(mpq(1,3));
+1/3
+SELECT abs(mpq(-1,3));
+1/3
+SELECT abs(mpq(1,-3));
+1/3
+SELECT abs(mpq(-1,-3));
+1/3
+SELECT inv(mpq(1,3));
+3
+SELECT inv(mpq(-1,3));
+-3
+SELECT inv(mpq(3,1));
+1/3
+SELECT inv(mpq(-3,1));
+-1/3
+SELECT inv(0::mpq);
+ERROR:  division by zero
+SELECT limit_den(3.141592653589793, 10);
+22/7
+SELECT limit_den(3.141592653589793, 100);
+311/99
+SELECT limit_den(3.141592653589793, 1000000);
+3126535/995207
+SELECT limit_den(3.141592653589793);
+3126535/995207
+SELECT limit_den('4321/8765', 10000);
+4321/8765
+SELECT limit_den(3.141592653589793, 10000);
+355/113
+SELECT limit_den(-3.141592653589793, 10000);
+-355/113
+SELECT limit_den(3.141592653589793, 113);
+355/113
+SELECT limit_den(3.141592653589793, 112);
+333/106
+SELECT limit_den('201/200', 100);
+1
+SELECT limit_den('201/200', 101);
+102/101
+SELECT limit_den(0, 10000);
+0
+--
+-- mpq ordering operators
+--
+select 1000::mpq =   999::mpq;
+f
+select 1000::mpq =  1000::mpq;
+t
+select 1000::mpq =  1001::mpq;
+f
+select 1000::mpq <>  999::mpq;
+t
+select 1000::mpq <> 1000::mpq;
+f
+select 1000::mpq <> 1001::mpq;
+t
+select 1000::mpq !=  999::mpq;
+t
+select 1000::mpq != 1000::mpq;
+f
+select 1000::mpq != 1001::mpq;
+t
+select 1000::mpq <   999::mpq;
+f
+select 1000::mpq <  1000::mpq;
+f
+select 1000::mpq <  1001::mpq;
+t
+select 1000::mpq <=  999::mpq;
+f
+select 1000::mpq <= 1000::mpq;
+t
+select 1000::mpq <= 1001::mpq;
+t
+select 1000::mpq >   999::mpq;
+t
+select 1000::mpq >  1000::mpq;
+f
+select 1000::mpq >  1001::mpq;
+f
+select 1000::mpq >=  999::mpq;
+t
+select 1000::mpq >= 1000::mpq;
+t
+select 1000::mpq >= 1001::mpq;
+f
+select mpq_cmp(1000::mpq,  999::mpq);
+1
+select mpq_cmp(1000::mpq, 1000::mpq);
+0
+select mpq_cmp(1000::mpq, 1001::mpq);
+-1
+-- Can create btree and hash indexes
+create table test_mpq_idx (q mpq);
+insert into test_mpq_idx select generate_series(1, 10000);
+create index test_mpq_btree_idx on test_mpq_idx using btree (q);
+set client_min_messages = error;
+create index test_mpq_hash_idx on test_mpq_idx using hash (q);
+reset client_min_messages;
+-- Hash is compatible with mpz
+select mpq_hash(0) = mpz_hash(0);
+t
+select mpq_hash(1000) = mpz_hash(1000);
+t
+select mpq_hash(-1000) = mpz_hash(-1000);
+t
+select mpq_hash('123456789012345678901234567890123456789012345678901234567890')
+     = mpz_hash('123456789012345678901234567890123456789012345678901234567890');
+t
+-- den is used in hash
+select mpq_hash(2) <> mpq_hash('2/3');
+t
+select mpq_hash('2/3') <> mpq_hash('2/5');
+t
+--
+-- mpq aggregation
+--
+CREATE TABLE mpqagg(q mpq);
+SELECT sum(q) FROM mpqagg;      -- NULL sum
+
+INSERT INTO mpqagg SELECT mpq(x+1, x) from generate_series(1, 100) x;
+INSERT INTO mpqagg VALUES (NULL);
+SELECT sum(q) FROM mpqagg;
+293348137198370259818356753784353345674911/2788815009188499086581352357412492142272
+SELECT prod(q) FROM mpqagg;
+101
+SELECT min(q) FROM mpqagg;
+101/100
+SELECT max(q) FROM mpqagg;
+2
+-- check correct values when the sortop kicks in
+CREATE INDEX mpqagg_idx ON mpqagg(q);
+SELECT min(q) FROM mpqagg;
+101/100
+SELECT max(q) FROM mpqagg;
+2
+-- check aggregates work in windows functions too
+CREATE TABLE test_mpq_win(q mpq);
+INSERT INTO test_mpq_win SELECT mpq(1::mpz, i::mpz) from generate_series(1,500) i;
+SELECT DISTINCT den(q) % 5, prod(q) OVER (PARTITION BY den(q) % 5) FROM test_mpq_win ORDER BY 1;
+0|1/736214027959609564214534807933509860360590478604140717816562255320550732004257967720125762877551166630104095572009682655334472656250000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+1|1/4024980661396945255594437948691099096750750303522148939207253140343256389690134608552507750666273153464851186606092569064940061274937877687035835465562596381725444297753023206467590336262178237450463859369896155905624559845376
+2|1/20916546636333781039819147945471434631041853197955027503272329909375076603172061212536955170894771081399258164490448681039306210750168807043358712676705447209588907620793116406518489750133917827418353041315415425444640641253376
+3|1/78258648528733027168387470491499343638520216905903130597214530733536396165915793335397652314194905058465162496835320770455185720537199021723403297752439421984679965716575544045339560632302893082461947076538277070518358298853376
+4|1/251546524835575501784021324366402680054179057461650771690723123931592596438400569072874480196699629786768776600250612669749873513568533129791068662565559263147495268772282292685896436853700130137800525196100073761792376099045376


### PR DESCRIPTION
Hi @dvarrazzo ,

Attached are patches against master that fixes regression tests against PG 19 and also fixes build warnings against all recent PostgreSQL versions.

Cheers, Devrim

Per: https://github.com/pgdg-packaging/pgdg-rpms/issues/213